### PR TITLE
Update DeepseekLaravelFacade.php

### DIFF
--- a/src/DeepseekLaravelFacade.php
+++ b/src/DeepseekLaravelFacade.php
@@ -2,7 +2,9 @@
 
 namespace DeepSeek\DeepseekLaravel;
 
+use DeepSeek\DeepSeekClient;
 use Illuminate\Support\Facades\Facade;
+
 
 class DeepseekLaravelFacade extends Facade
 {
@@ -13,6 +15,6 @@ class DeepseekLaravelFacade extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'deepseek-laravel';
+        return DeepSeekClient::class;
     }
 }


### PR DESCRIPTION
The registered component name '[deepseek-laravel]' is incorrect here because it is not linked in the instance in the service provider.

Solution register as DeepSeekClient::class