### PR TITLE
Enforce Laravel 12.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": "^8.1.0",
         "deepseek-php/deepseek-php-client": "^2.0",
-        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "nyholm/psr7": "^1.8",
         "symfony/http-client": "^7.2"
     },


### PR DESCRIPTION
I am using the Laravel 12 version. I hope to incorporate the component you developed into my program. Therefore, I have forced the adaptation to Laravel 12. I hope you can spare some time to take a look and see if it can be compatible.